### PR TITLE
Modify Vue component export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export { default } from './components/vue-resizable'
+export { default } from './components/vue-resizable.vue'


### PR DESCRIPTION
The default component export does not explicitly export the `VueResizable` component from the `.vue` file extension, which causes import failures when using Vite instead of vue-loader. 

```
(this will be run only when your dependencies or config have changed)
node_modules/vue-resizable/src/index.js:1:24: error: Could not resolve "./components/vue-resizable"
    1 │ export { default } from './components/vue-resizable';
      ╵                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error when starting dev server:
Error: Build failed with 1 error:
node_modules/vue-resizable/src/index.js:1:24: error: Could not resolve "./components/vue-resizable"
    at failureErrorWithLog (/home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:1224:15)
    at buildResponseToResult (/home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:936:32)
    at /home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:1035:20
    at /home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:568:9
    at handleIncomingPacket (/home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:657:9)
    at Socket.readFromStdout (/home/bigcookie/projects/vue-resizable-test/node_modules/esbuild/lib/main.js:535:7)
    at Socket.emit (events.js:315:20)
    at addChunk (internal/streams/readable.js:309:12)
    at readableAddChunk (internal/streams/readable.js:284:9)
    at Socket.Readable.push (internal/streams/readable.js:223:10)
```
Defining the `.vue` extension explicitly fixes this issue with Vite and does not cause issues with vue-loader. 

This can be verified by modifying the component import in `docs/App.vue` from:
```js
import VueResizable from '../src/components/vue-resizable'
```
to:
```js
import VueResizable from "../src/"
// or import VueResizable from "../src/index"
```
so that the component is imported from the module instead of directly from the component.