### PR TITLE
Fixed compatibility with vue 2, added beforeDestoy hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-resizable",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Vue2 component that allows to resize and drag elements",
   "main": "dist/main.js",
   "jsnext:main": "src/index.js",

--- a/src/components/vue-resizable.vue
+++ b/src/components/vue-resizable.vue
@@ -244,8 +244,12 @@ export default {
     document.documentElement.addEventListener("touchend", this.handleUp, true);
     this.emitEvent("mount");
   },
-  beforeUnmount: this.onDestroy,
-  beforeDestoy: this.onDestroy,
+  beforeUnmount() {
+    this.onDestroy()
+  },
+  beforeDestroy() {
+    this.onDestroy()
+  },
   methods: {
     setMaximize(value) {
       const parentEl = this.$el.parentElement;

--- a/src/components/vue-resizable.vue
+++ b/src/components/vue-resizable.vue
@@ -244,40 +244,8 @@ export default {
     document.documentElement.addEventListener("touchend", this.handleUp, true);
     this.emitEvent("mount");
   },
-  beforeUnmount() {
-    document.documentElement.removeEventListener(
-        "mousemove",
-        this.handleMove,
-        true
-    );
-    document.documentElement.removeEventListener(
-        "mousedown",
-        this.handleDown,
-        true
-    );
-    document.documentElement.removeEventListener(
-        "mouseup",
-        this.handleUp,
-        true
-    );
-
-    document.documentElement.removeEventListener(
-        "touchmove",
-        this.handleMove,
-        true
-    );
-    document.documentElement.removeEventListener(
-        "touchstart",
-        this.handleDown,
-        true
-    );
-    document.documentElement.removeEventListener(
-        "touchend",
-        this.handleUp,
-        true
-    );
-    this.emitEvent("destroy");
-  },
+  beforeUnmount: this.onDestroy,
+  beforeDestoy: this.onDestroy,
   methods: {
     setMaximize(value) {
       const parentEl = this.$el.parentElement;
@@ -471,6 +439,40 @@ export default {
         this.emitEvent(eventName);
         this.dragState = false;
       }
+    },
+    onDestroy() {
+      document.documentElement.removeEventListener(
+          "mousemove",
+          this.handleMove,
+          true
+      );
+      document.documentElement.removeEventListener(
+          "mousedown",
+          this.handleDown,
+          true
+      );
+      document.documentElement.removeEventListener(
+          "mouseup",
+          this.handleUp,
+          true
+      );
+
+      document.documentElement.removeEventListener(
+          "touchmove",
+          this.handleMove,
+          true
+      );
+      document.documentElement.removeEventListener(
+          "touchstart",
+          this.handleDown,
+          true
+      );
+      document.documentElement.removeEventListener(
+          "touchend",
+          this.handleUp,
+          true
+      );
+      this.emitEvent("destroy");
     }
   }
 };

--- a/src/components/vue-resizable.vue
+++ b/src/components/vue-resizable.vue
@@ -244,8 +244,12 @@ export default {
     document.documentElement.addEventListener("touchend", this.handleUp, true);
     this.emitEvent("mount");
   },
-  beforeUnmount: this.onDestroy,
-  beforeDestoy: this.onDestroy,
+  beforeUnmount() {
+    this.onDestroy()
+  },
+  beforeDestoy() {
+    this.onDestroy()
+  },
   methods: {
     setMaximize(value) {
       const parentEl = this.$el.parentElement;


### PR DESCRIPTION
Vue 2 has no beforeUnmount lifecycle hook, so the events are not deleted in the browser and continue to live until the page reloads. When running for a long time, this significantly slows down the application.